### PR TITLE
set archivesBaseName

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ allprojects {
     ext.libPrettyVersion = buildProperties.getProperty("library.prettyVersion")
     ext.javaVersion = buildProperties.getProperty("java.target.version")
 
+    project.archivesBaseName = libName
+ 
+
     ext.userHome = System.getProperty("user.home")
     ext.sketchbookLocation = buildProperties.getProperty("sketchbook.location").replace("\${user.home}", userHome)
     ext.replaceEnv = { value ->


### PR DESCRIPTION
After I created the pull request, I found a small issue (the base name for the packages was not set, so gradle used the folder name). This is fixed in this new PR. For more info, the new processing-android template library is [here](https://github.com/processing/processing-android-library-template/).